### PR TITLE
set seed & add linebreaks in data_preprocess examples

### DIFF
--- a/R/sort_alluvial.R
+++ b/R/sort_alluvial.R
@@ -659,21 +659,39 @@ randomly_map_int_columns <- function(clus_df_gather) {
 #' @return A data frame where each row represents a combination of groupings, each column from \code{cols} represents a grouping, and the column \code{wt} ('value' if \code{wt} == NULL) represents the number of entities in that combination of groupings. For each column in \code{cols}, there will be an additional column \code{col1_int}, \code{col2_int}, etc. where each column corresponds to a position mapping of groupings in the respective entry of \code{cols} - for example, \code{col1_int} corresponds to \code{cols[1]}, \code{col2_int} corresponds to \code{cols[2]}, etc.
 #'
 #' @examples
+#' set.seed(235488)
+#' data <- data.frame(
+#'   method1 = sample(1:3, 100, TRUE),
+#'   method2 = sample(4:6, 100, TRUE)
+#' )
+#' head(data)
+#' lapply(data, unique)
+#' 
 #' # Example 1: data format 1
-#' data <- data.frame(method1 = sample(1:3, 100, TRUE), method2 = sample(1:3, 100, TRUE))
-#' clus_df_gather <- data_preprocess(data, cols = c("method1", "method2"))
+#' clus_df_gather <- data_preprocess(
+#'   data,
+#'   cols = c("method1", "method2")
+#' )
+#' print(clus_df_gather)
+#' lapply(clus_df_gather[, 1:2], levels)
 #'
 #' # Example 2: data format 2
-#' data <- data.frame(method1 = sample(1:3, 100, TRUE), method2 = sample(1:3, 100, TRUE))
 #' clus_df_gather <- data |>
-#'     dplyr::mutate_if(is.numeric, function(x) factor(x, levels = as.character(sort(unique(x))))) |>
+#'     dplyr::mutate_if(
+#'       is.numeric,
+#'       function(x) factor(x, levels = as.character(sort(unique(x))))
+#'     ) |>
 #'     dplyr::group_by_all() |>
 #'     dplyr::count(name = "value")
+#' print(clus_df_gather)
+#' lapply(clus_df_gather[, 1:2], unique)
 #' clus_df_gather <- data_preprocess(
-#'     clus_df_gather,
-#'     cols = c("method1", "method2"),
-#'     wt = "value"
+#'   clus_df_gather,
+#'   cols = c("method1", "method2"),
+#'   wt = "value"
 #' )
+#' print(clus_df_gather)
+#' lapply(clus_df_gather[, 1:2], unique)
 #'
 #' @export
 data_preprocess <- function(data, cols, wt = NULL, default_sorting = "alphabetical", verbose = FALSE, print_params = FALSE, do_gather_set_data = FALSE, color_band_column = NULL, do_add_int_columns = FALSE) {

--- a/R/sort_alluvial.R
+++ b/R/sort_alluvial.R
@@ -649,7 +649,7 @@ randomly_map_int_columns <- function(clus_df_gather) {
 #' (2) wt != NULL: Each row represents a combination of groupings, each column from \code{cols} represents a grouping, and the column \code{wt} represents the number of entities in that combination of groupings. Must contain at least three columns (two \code{cols}, one \code{wt}).
 #' @param cols Character vector. Vector of column names from \code{data} to be used in graphing (i.e., alluvial plotting).
 #' @param wt Optional character. Column name from \code{data} that contains the weights of each combination of groupings if \code{data} is in format (2) (see above).
-#' @param default_sorting Character. Default column sorting in data_preprocess if integer columns do not exist. Options are 'alphabetical' (default), 'reverse_alphabetical', 'increasing', 'decreasing', 'random'.
+#' @param default_sorting Character. Default column sorting in [data_preprocess()] if integer columns do not exist. Options are 'alphabetical' (default), 'reverse_alphabetical', 'increasing', 'decreasing', 'random'.
 #' @param verbose Logical. If TRUE, will display messages during the function.
 #' @param print_params Logical. If TRUE, will print function params.
 #' @param do_gather_set_data Internal flag; not recommended to modify.
@@ -860,7 +860,7 @@ sort_greedy_wolf <- function(clus_df_gather, cols = NULL, fixed_column = NULL, w
 #' Control Options for `data_sort()`
 #'
 #' Creates a list of control parameters that modify the behavior of
-#' `data_sort()`. These options allow tuning algorithmic behavior without
+#' [data_sort()]. These options allow tuning algorithmic behavior without
 #' cluttering the main function arguments.
 #'
 #' @param optimize_column_order_per_cycle Logical. If TRUE, will optimize the order of \code{cols} to minimize edge overlap upon each cycle. If FALSE, will optimize the order of \code{cols} to minimize edge overlap on the beginning cycle only. Only applies when \code{method == 'tsp'} and \code{length(cols) > 2}.
@@ -872,12 +872,12 @@ sort_greedy_wolf <- function(clus_df_gather, cols = NULL, fixed_column = NULL, w
 #' @param weighted_metric Logical. weighted_metric objective
 #' @param cycle_start_positions Set. Cycle start positions to consider. Anything outside this set will be skipped. Only applies when \code{method == 'tsp'}.
 #' @param random_initializations Integer. Number of random initializations for the positions of each grouping in \code{cols}. Only applies when \code{method == 'greedy_wolf' or method == 'greedy_wblf'}.
-#' @param preprocess_data Logical. If TRUE, will preprocess the data with the \code{data_preprocess} function.
-#' @param default_sorting Character. Default column sorting in data_preprocess if integer columns do not exist. Options are 'alphabetical' (default), 'reverse_alphabetical', 'increasing', 'decreasing', 'random'.
+#' @param preprocess_data Logical. If TRUE, will preprocess the data with the [data_preprocess()] function.
+#' @param default_sorting Character. Default column sorting in [data_preprocess()] if integer columns do not exist. Options are 'alphabetical' (default), 'reverse_alphabetical', 'increasing', 'decreasing', 'random'.
 #' @param print_params Logical. If TRUE, will print function params.
 #' @param do_compute_alluvial_statistics Internal flag; not recommended to modify.
 #' 
-#' @return A named list of control parameters, to be passed into `data_sort()`
+#' @return A named list of control parameters, to be passed into [data_sort()]
 #'   via the `options` argument.
 #'
 #' @examples
@@ -1082,7 +1082,7 @@ data_sort_internal <- function(data, cols, wt = NULL, method = c("tsp", "neighbo
 #' @param weight_scalar Positive integer. Scalar with which to multiply edge weights after taking their -log in the distance matrix for nodes with a nonzero edge. Only applies when \code{method == 'tsp'}.
 #' @param fixed_column Character or Integer. Name or position of the column in \code{cols} to keep fixed during sorting. Only applies when \code{method == 'greedy_wolf'}.
 #' @param verbose Logical. If TRUE, will display messages during the function.
-#' @param options Additional arguments. See data_sort_options
+#' @param options Additional arguments. See [data_sort_options()].
 #'
 #' @return
 #' A data frame where each row represents an alluvium and each column represents an axis. Each column of \code{cols} represents an axis, stored as a factor ordered in ascending order of strata. There is an additional column \code{wt} ('value' if NULL) that represents the size of the alluvium in that row. The order of columns represents the recommended order of axes.

--- a/man/data_preprocess.Rd
+++ b/man/data_preprocess.Rd
@@ -25,7 +25,7 @@ data_preprocess(
 
 \item{wt}{Optional character. Column name from \code{data} that contains the weights of each combination of groupings if \code{data} is in format (2) (see above).}
 
-\item{default_sorting}{Character. Default column sorting in data_preprocess if integer columns do not exist. Options are 'alphabetical' (default), 'reverse_alphabetical', 'increasing', 'decreasing', 'random'.}
+\item{default_sorting}{Character. Default column sorting in \code{\link[=data_preprocess]{data_preprocess()}} if integer columns do not exist. Options are 'alphabetical' (default), 'reverse_alphabetical', 'increasing', 'decreasing', 'random'.}
 
 \item{verbose}{Logical. If TRUE, will display messages during the function.}
 

--- a/man/data_preprocess.Rd
+++ b/man/data_preprocess.Rd
@@ -44,20 +44,38 @@ A data frame where each row represents a combination of groupings, each column f
 Preprocess data (load in, add integer columns, reorder columns to match cols, and group as needed)
 }
 \examples{
+set.seed(235488)
+data <- data.frame(
+  method1 = sample(1:3, 100, TRUE),
+  method2 = sample(4:6, 100, TRUE)
+)
+head(data)
+lapply(data, unique)
+
 # Example 1: data format 1
-data <- data.frame(method1 = sample(1:3, 100, TRUE), method2 = sample(1:3, 100, TRUE))
-clus_df_gather <- data_preprocess(data, cols = c("method1", "method2"))
+clus_df_gather <- data_preprocess(
+  data,
+  cols = c("method1", "method2")
+)
+print(clus_df_gather)
+lapply(clus_df_gather[, 1:2], levels)
 
 # Example 2: data format 2
-data <- data.frame(method1 = sample(1:3, 100, TRUE), method2 = sample(1:3, 100, TRUE))
 clus_df_gather <- data |>
-    dplyr::mutate_if(is.numeric, function(x) factor(x, levels = as.character(sort(unique(x))))) |>
+    dplyr::mutate_if(
+      is.numeric,
+      function(x) factor(x, levels = as.character(sort(unique(x))))
+    ) |>
     dplyr::group_by_all() |>
     dplyr::count(name = "value")
+print(clus_df_gather)
+lapply(clus_df_gather[, 1:2], unique)
 clus_df_gather <- data_preprocess(
-    clus_df_gather,
-    cols = c("method1", "method2"),
-    wt = "value"
+  clus_df_gather,
+  cols = c("method1", "method2"),
+  wt = "value"
 )
+print(clus_df_gather)
+lapply(clus_df_gather[, 1:2], unique)
 
 }

--- a/man/data_sort.Rd
+++ b/man/data_sort.Rd
@@ -35,7 +35,7 @@ data_sort(
 
 \item{verbose}{Logical. If TRUE, will display messages during the function.}
 
-\item{options}{Additional arguments. See data_sort_options}
+\item{options}{Additional arguments. See \code{\link[=data_sort_options]{data_sort_options()}}.}
 }
 \value{
 A data frame where each row represents an alluvium and each column represents an axis. Each column of \code{cols} represents an axis, stored as a factor ordered in ascending order of strata. There is an additional column \code{wt} ('value' if NULL) that represents the size of the alluvium in that row. The order of columns represents the recommended order of axes.

--- a/man/data_sort_options.Rd
+++ b/man/data_sort_options.Rd
@@ -40,21 +40,21 @@ data_sort_options(
 
 \item{random_initializations}{Integer. Number of random initializations for the positions of each grouping in \code{cols}. Only applies when \code{method == 'greedy_wolf' or method == 'greedy_wblf'}.}
 
-\item{preprocess_data}{Logical. If TRUE, will preprocess the data with the \code{data_preprocess} function.}
+\item{preprocess_data}{Logical. If TRUE, will preprocess the data with the \code{\link[=data_preprocess]{data_preprocess()}} function.}
 
-\item{default_sorting}{Character. Default column sorting in data_preprocess if integer columns do not exist. Options are 'alphabetical' (default), 'reverse_alphabetical', 'increasing', 'decreasing', 'random'.}
+\item{default_sorting}{Character. Default column sorting in \code{\link[=data_preprocess]{data_preprocess()}} if integer columns do not exist. Options are 'alphabetical' (default), 'reverse_alphabetical', 'increasing', 'decreasing', 'random'.}
 
 \item{print_params}{Logical. If TRUE, will print function params.}
 
 \item{do_compute_alluvial_statistics}{Internal flag; not recommended to modify.}
 }
 \value{
-A named list of control parameters, to be passed into \code{data_sort()}
+A named list of control parameters, to be passed into \code{\link[=data_sort]{data_sort()}}
 via the \code{options} argument.
 }
 \description{
 Creates a list of control parameters that modify the behavior of
-\code{data_sort()}. These options allow tuning algorithmic behavior without
+\code{\link[=data_sort]{data_sort()}}. These options allow tuning algorithmic behavior without
 cluttering the main function arguments.
 }
 \examples{


### PR DESCRIPTION
This is a minor edit to one set of examples that sets a random seed for reproducibility and reformats code for ease of viewing in a narrower console printout or IDE pane.

EDIT: Now also uses `[<name>()]` syntax to instruct {roxygen2} to hyperlink between pages.